### PR TITLE
providing `indexing` to numpy.meshgrid

### DIFF
--- a/powerbox/powerbox.py
+++ b/powerbox/powerbox.py
@@ -257,11 +257,12 @@ class PowerBox(object):
         dx = self.delta_x()
         dx = (dx + 1) * self.dx ** self.dim * nbar
         n = dx
+
         self.n_per_cell = np.random.poisson(n)
 
         # Get all source positions
         args = [self.x] * self.dim
-        X = np.meshgrid(*args)
+        X = np.meshgrid(*args, indexing='ij')
 
         tracer_positions = np.array([x.flatten() for x in X]).T
         tracer_positions = tracer_positions.repeat(self.n_per_cell.flatten(), axis=0)

--- a/tests/test_discrete.py
+++ b/tests/test_discrete.py
@@ -8,18 +8,31 @@ sys.path.insert(0, LOCATION)
 
 from powerbox import PowerBox, LogNormalPowerBox, get_power
 
-
 def test_discrete_power_gaussian():
-    pb = PowerBox(N=512,dim=2,boxlength=100., pk = lambda u : 0.1*u**-1.5, ensure_physical=True)
+    # Supply `seed` to ensure that discrete sample corresponds to box.
+    pb = PowerBox(N=512,dim=2,boxlength=100., pk = lambda u : 0.1*u**-1.5,
+        ensure_physical=True, seed=2468)
 
     sample = pb.create_discrete_sample(nbar=1000.)
     power, bins = get_power(sample,pb.boxlength,N=pb.N)
 
-
     res =  np.mean(np.abs(power[50:-50] / (0.1*bins[50:-50]**-1.5) -1 ) )
 
-    print(res)
     assert res < 1e-1
+
+    # This re-grids the discrete sample into a box, basically to verify the
+    # indexing used by meshgrid within `create_discrete_sample`.
+    N = [pb.N] * pb.dim
+    L = [pb.boxlength] * pb.dim
+    edges = [np.linspace(-_L/2., _L/2., _n + 1) for _L, _n in zip(L, N)]
+    delta_samp = np.histogramdd(sample, bins=edges, weights=None)[0].astype("float")
+
+    # Check cross spectrum and assert a strong correlation
+    cross, bins = get_power(delta_samp,pb.boxlength,deltax2=pb.delta_x())
+    p2, bins = get_power(pb.delta_x(), pb.boxlength)
+    corr = cross / np.sqrt(power) / np.sqrt(p2)
+    corr_bar = np.mean(corr[np.isfinite(corr)])
+    assert corr_bar > 10
 
 def test_discrete_power_lognormal():
     pb = LogNormalPowerBox(N=512, dim=2, boxlength=100., pk=lambda u: 0.1*u ** -1.5, ensure_physical=True)
@@ -29,5 +42,8 @@ def test_discrete_power_lognormal():
 
     res = np.mean(np.abs(power[50:-50]/(0.1*bins[50:-50] ** -1.5) - 1))
 
-    print(res)
     assert res < 1e-1
+
+if __name__ == '__main__':
+    test_discrete_power_gaussian()
+    test_discrete_power_lognormal()


### PR DESCRIPTION
This ensures correspondence between discrete samples and parent field, resolving issue #15 