### PR TITLE
fix: make sure int values of boxlength are converted to floats

### DIFF
--- a/src/powerbox/tools.py
+++ b/src/powerbox/tools.py
@@ -1120,7 +1120,9 @@ def get_power(
         dim = len(deltax.shape)
 
         if not np.iterable(boxlength):
-            boxlength = [boxlength] * dim
+            boxlength = [boxlength + 0.0] * dim
+        else:
+            boxlength = [val + 0.0 for val in boxlength]
 
         if deltax2 is not None and deltax.shape != deltax2.shape:
             raise ValueError("deltax and deltax2 must have the same shape!")

--- a/src/powerbox/tools.py
+++ b/src/powerbox/tools.py
@@ -1120,9 +1120,9 @@ def get_power(
         dim = len(deltax.shape)
 
         if not np.iterable(boxlength):
-            boxlength = [boxlength + 0.0] * dim
+            boxlength = [float(boxlength)] * dim
         else:
-            boxlength = [val + 0.0 for val in boxlength]
+            boxlength = [float(val) for val in boxlength]
 
         if deltax2 is not None and deltax.shape != deltax2.shape:
             raise ValueError("deltax and deltax2 must have the same shape!")

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -121,6 +121,9 @@ def test_k_weights_fnc():
     pb = PowerBox(50, dim=3, pk=lambda k: 1.0 * k**-2.0, boxlength=1.0, b=1)
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message="invalid value encountered in divide")
+        warnings.filterwarnings(
+            "ignore", message="One or more radial bins had no cells within it"
+        )
         p_ki0, k_ki0 = get_power(pb.delta_x(), pb.boxlength, k_weights=ignore_zero_ki)
     p, k = get_power(pb.delta_x(), pb.boxlength, k_weights=ignore_zero_absk)
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -459,6 +459,9 @@ def test_cross_power_identity():
     p, k = get_power(dx, pb.boxlength, b=1)
     p_cross, k = get_power(dx, pb.boxlength, b=1, deltax2=dx)
     assert np.all(np.isclose(p, p_cross))
+    p, k = get_power(dx, [1, 1], b=1)
+    p_cross, k = get_power(dx, [1, 1], b=1, deltax2=dx)
+    assert np.all(np.isclose(p, p_cross))
 
 
 @pytest.mark.skip()


### PR DESCRIPTION
When I input an int value of `boxlength` to `get_power` I get a very different (and wrong) power spectrum.
We should just include all the input types for all functions, but in the meantime, I added a quick fix where `0.0` is added to the `boxlength` to make sure it is a float.