### PR TITLE
deps: require numpy>2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ license= {text= "MIT"}
 requires-python = ">=3.11"
 keywords=["power-spectrum", "signal processing"]
 dependencies = [
-    "numpy>1.6.2"
+    "numpy>2.2"
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ license= {text= "MIT"}
 requires-python = ">=3.11"
 keywords=["power-spectrum", "signal processing"]
 dependencies = [
-    "numpy>2.2"
+    "numpy>=2.2"
 ]
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Fixes #80 

This updates requirements to numpy >=2.2, which avoids the problems with astropy units reported in the above issue.