### PR TITLE
Add cuboid PowerBox support

### DIFF
--- a/docs/demos/cuboid_boxes.rst
+++ b/docs/demos/cuboid_boxes.rst
@@ -1,0 +1,73 @@
+Cuboid boxes
+============
+
+As of v1.0, ``PowerBox`` and ``LogNormalPowerBox`` can be constructed with per-axis grid
+sizes and side lengths. This is useful when one axis of the target volume needs a
+different physical extent or resolution from the others.
+
+Constructing a non-cubic Gaussian field
+---------------------------------------
+
+Pass tuples for ``N`` and ``boxlength`` with one entry per dimension:
+
+.. code-block:: python
+
+   import matplotlib.pyplot as plt
+
+   from powerbox import PowerBox
+
+   pb = PowerBox(
+       N=(128, 192),
+       dim=2,
+       boxlength=(200.0, 600.0),
+       pk=lambda k: (1 + k) ** -2.0,
+       seed=1234,
+   )
+
+   field = pb.delta_x()
+   x, y = pb.x
+
+   plt.imshow(
+       field,
+       extent=(y[0], y[-1], x[0], x[-1]),
+       aspect="auto",
+       origin="lower",
+   )
+   plt.xlabel("y")
+   plt.ylabel("x")
+   plt.title("Gaussian cuboid field")
+
+The same constructor pattern works for :class:`powerbox.LogNormalPowerBox`.
+
+Checking the recovered power spectrum
+-------------------------------------
+
+The resulting field can be passed straight into :func:`powerbox.get_power` with the same
+per-axis ``boxlength`` tuple:
+
+.. code-block:: python
+
+   import matplotlib.pyplot as plt
+
+   from powerbox import get_power
+
+   result = get_power(field, pb.boxlength, bins_upto_boxlen=True)
+
+   plt.loglog(result.bin_avg[1:], result.power[1:], label="measured")
+   plt.loglog(result.bin_avg[1:], (1 + result.bin_avg[1:]) ** -2.0, label="input")
+   plt.xlabel("k")
+   plt.ylabel("P(k)")
+   plt.legend()
+
+Working with discrete samples
+-----------------------------
+
+Discrete sampling uses the same geometry:
+
+.. code-block:: python
+
+   sample = pb.create_discrete_sample(nbar=1e-2, min_at_zero=True)
+   discrete_result = get_power(sample, pb.boxlength, N=pb.N, bins_upto_boxlen=True)
+
+When scalar values are passed for ``N`` and ``boxlength``, existing workflows are
+unchanged.

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -8,6 +8,7 @@ Other examples can be found in the :doc:`API documentation <api>` for each objec
    :maxdepth: 2
 
    demos/getting_started
+   demos/cuboid_boxes
    demos/algorithm
    demos/cosmological_fields
    demos/dft

--- a/src/powerbox/powerbox.py
+++ b/src/powerbox/powerbox.py
@@ -10,7 +10,9 @@ subclassing :class:`PowerBox` and over-writing the same methods as are over-writ
 from __future__ import annotations
 
 import itertools
+import numbers
 import warnings
+from collections.abc import Sequence
 
 import numpy as np
 
@@ -45,24 +47,65 @@ def _make_hermitian(mag, pha):
     return mag * (np.cos(pha) + 1j * np.sin(pha))
 
 
+def _normalize_axis_counts(
+    N: int | Sequence[int], dim: int
+) -> tuple[int | tuple[int, ...], tuple[int, ...]]:
+    """Normalize grid counts to a per-axis tuple while preserving scalar public input."""
+    if isinstance(N, numbers.Integral):
+        scalar = int(N)
+        return scalar, (scalar,) * dim
+
+    values = tuple(N)
+    if len(values) != dim:
+        raise ValueError(f"N must be a scalar or have length {dim}.")
+
+    if not all(isinstance(value, numbers.Integral) for value in values):
+        raise TypeError("N entries must be integers.")
+
+    normalized = tuple(int(value) for value in values)
+    return normalized, normalized
+
+
+def _normalize_axis_lengths(
+    boxlength: float | Sequence[float], dim: int
+) -> tuple[float | tuple[float, ...], tuple[float, ...]]:
+    """Normalize box lengths to a per-axis tuple while preserving scalar public input."""
+    if isinstance(boxlength, numbers.Real):
+        scalar = float(boxlength)
+        return scalar, (scalar,) * dim
+
+    values = tuple(boxlength)
+    if len(values) != dim:
+        raise ValueError(f"boxlength must be a scalar or have length {dim}.")
+
+    if not all(isinstance(value, numbers.Real) for value in values):
+        raise TypeError("boxlength entries must be real numbers.")
+
+    normalized = tuple(float(value) for value in values)
+    return normalized, normalized
+
+
 class PowerBox:
     r"""
     Generate real- and fourier-space Gaussian fields with a given power spectrum.
 
     Parameters
     ----------
-    N : int
-        Number of grid-points on a side for the resulting box (equivalently, number of
-        wavenumbers to use).
+    N : int or sequence of int
+        Number of grid-points on each side of the resulting box (equivalently, number of
+        wavenumbers to use). If a scalar, the same number is used along every axis. If a
+        sequence, it must have length ``dim``.
     pk : callable
         A callable of a single (vector) variable `k`, which is the isotropic power
         spectrum. The relationship of the `k` of which this is a function to the
         real-space co-ordinates, `x`, is determined by the parameters ``a,b``.
     dim : int, default 2
         Number of dimensions of resulting box.
-    boxlength : float, default 1.0
-        Length of the final signal on a side. This may have arbitrary units, so long
-        as `pk` is a function of a variable which has the inverse units.
+    boxlength : float or sequence of float, default 1.0
+        Length of the final signal along each axis. This may have arbitrary units, so
+        long as `pk` is a function of a variable which has the inverse units. If a
+        scalar, the same length is used along every axis. If a sequence, it must have
+        length ``dim``.
     ensure_physical : bool, optional
         Interpreting the power spectrum as a spectrum of density fluctuations, the
         minimum physical value of the real-space field, :meth:`delta_x`, is -1. With
@@ -105,6 +148,11 @@ class PowerBox:
     enables its direct interpretation as an overdensity field, and this interpretation
     is enforced in the :meth:`make_discrete_sample` method.
 
+    When scalar ``N`` and scalar ``boxlength`` are provided, the public attributes
+    ``N``, ``boxlength``, ``x``, and ``kvec`` retain their historical scalar/1-D forms.
+    When either quantity is specified per-axis, ``x`` and ``kvec`` return tuples of
+    1-D arrays, one for each axis.
+
     .. note:: None of the n-dimensional arrays that are created within the class are
               stored, due to the inefficiency in memory consumption that this would
               imply. Thus, each large array is created and *returned* by their
@@ -129,14 +177,20 @@ class PowerBox:
     >>> import matplotlib.pyplot as plt
     >>> pb = PowerBox(1000, lambda k : k**-7./5.)
     >>> plt.imshow(pb.delta_x())
+
+    To create a 2D non-cubic box with different resolutions and side lengths:
+
+    >>> pb = PowerBox((128, 192), lambda k: (1 + k) ** -2.0, dim=2, boxlength=(200.0, 600.0))
+    >>> field = pb.delta_x()
+    >>> x, y = pb.x
     """
 
     def __init__(
         self,
-        N: int,
+        N: int | Sequence[int],
         pk,
         dim: int = 2,
-        boxlength: float = 1.0,
+        boxlength: float | Sequence[float] = 1.0,
         ensure_physical: bool = False,
         a: float = 1.0,
         b: float = 1.0,
@@ -144,14 +198,15 @@ class PowerBox:
         seed: int | None = None,
         nthreads: int | None = None,
     ) -> None:
-        self.N = N
         self.dim = dim
-        self.boxlength = boxlength
-        self.L = boxlength
+        self.N, self._N = _normalize_axis_counts(N, dim)
+        self.boxlength, self._boxlength = _normalize_axis_lengths(boxlength, dim)
+        self.L = self.boxlength
+        self._scalar_geometry = np.isscalar(self.N) and np.isscalar(self.boxlength)
         self.fourier_a = a
         self.fourier_b = b
         self.vol_normalised_power = vol_normalised_power
-        self.V = self.boxlength**self.dim
+        self.V = float(np.prod(self._boxlength))
         self.fftbackend = dft.get_fft_backend(nthreads)
 
         if self.vol_normalised_power:
@@ -160,7 +215,7 @@ class PowerBox:
             self.pk = pk
 
         self.ensure_physical = ensure_physical
-        self.Ntot = self.N**self.dim
+        self.Ntot = int(np.prod(self._N))
 
         self.seed = seed
         if seed is None:
@@ -170,58 +225,85 @@ class PowerBox:
             # the Generator API required by modern NumPy.
             self.rng = np.random.Generator(np.random.MT19937(seed))
 
-        if N % 2 == 0:
-            self._even = True
-        else:
-            self._even = False
+        self._even_axes = tuple(axis_n % 2 == 0 for axis_n in self._N)
+        self._hermitian_shape = tuple(
+            axis_n + 1 if is_even else axis_n
+            for axis_n, is_even in zip(self._N, self._even_axes, strict=True)
+        )
 
-        self.n = N + 1 if self._even else N
+        dx = tuple(length / axis_n for length, axis_n in zip(self._boxlength, self._N, strict=True))
+        self.dx = dx[0] if self._scalar_geometry else dx
 
-        # Get the grid-size for the final real-space box.
-        self.dx = float(boxlength) / N
+    @property
+    def _kvec_axes(self) -> tuple[np.ndarray, ...]:
+        """The vector of wavenumbers along each axis."""
+        return tuple(
+            self.fftbackend.fftfreq(axis_n, d=axis_dx, b=self.fourier_b)
+            for axis_n, axis_dx in zip(self._N, self._axis_dx, strict=True)
+        )
+
+    @property
+    def _x_axes(self) -> tuple[np.ndarray, ...]:
+        """The co-ordinates of the grid along each axis."""
+        return tuple(
+            np.arange(-length / 2, length / 2, axis_dx)[:axis_n]
+            for length, axis_dx, axis_n in zip(self._boxlength, self._axis_dx, self._N, strict=True)
+        )
+
+    @property
+    def _axis_dx(self) -> tuple[float, ...]:
+        """Per-axis cell sizes."""
+        return tuple(
+            length / axis_n for length, axis_n in zip(self._boxlength, self._N, strict=True)
+        )
 
     def k(self):
         """Return the full grid of wavenumber magnitudes."""
-        return _magnitude_grid([self.kvec] * self.dim)
+        return _magnitude_grid(list(self._kvec_axes))
 
     @property
     def kvec(self):
-        """The vector of wavenumbers along a side."""
-        return self.fftbackend.fftfreq(self.N, d=self.dx, b=self.fourier_b)
+        """The wavenumber vector along a side or a tuple of per-axis vectors."""
+        return self._kvec_axes[0] if self._scalar_geometry else self._kvec_axes
 
     @property
     def r(self):
         """The radial position of every point in the grid."""
-        return _magnitude_grid([self.x] * self.dim)
+        return _magnitude_grid(list(self._x_axes))
 
     @property
     def x(self):
-        """The co-ordinates of the grid along a side."""
-        return np.arange(-self.boxlength / 2, self.boxlength / 2, self.dx)[: self.N]
+        """The grid co-ordinates along a side or a tuple of per-axis co-ordinates."""
+        return self._x_axes[0] if self._scalar_geometry else self._x_axes
 
     def gauss_hermitian(self):
         """Return a random array with Gaussian magnitudes and Hermitian symmetry."""
-        mag = self.rng.normal(0, 1, size=[self.n] * self.dim)
-        pha = 2 * np.pi * self.rng.uniform(size=[self.n] * self.dim)
+        mag = self.rng.normal(0, 1, size=self._hermitian_shape)
+        pha = 2 * np.pi * self.rng.uniform(size=self._hermitian_shape)
 
         dk = _make_hermitian(mag, pha)
 
-        if self._even:
-            cutidx = (slice(None, -1),) * self.dim
+        if any(self._even_axes):
+            cutidx = tuple(slice(None, -1 if is_even else None) for is_even in self._even_axes)
             dk = dk[cutidx]
 
-            N = self.N
             # After cutting, every element whose index is 0 along any axis
             # loses its Hermitian partner (which was at index N, now removed).
             # Re-enforce dk[j] = dk[(N-j)%N]* on each such boundary slice by
             # iterating over each axis and symmetrising its j=0 face in-place.
-            for ax in range(self.dim):
-                face_ranges = [range(N)] * (self.dim - 1)
+            for ax, is_even in enumerate(self._even_axes):
+                if not is_even:
+                    continue
+
+                face_ranges = [range(axis_n) for i, axis_n in enumerate(self._N) if i != ax]
                 for t in itertools.product(*face_ranges):
                     full = list(t)
                     full.insert(ax, 0)
                     full = tuple(full)
-                    neg = tuple((N - i) % N for i in full)
+                    neg = tuple(
+                        (axis_n - i) % axis_n if is_even else axis_n - 1 - i
+                        for i, axis_n, is_even in zip(full, self._N, self._even_axes, strict=True)
+                    )
                     if neg > full:
                         dk[neg] = np.conj(dk[full])
                     elif neg == full:
@@ -257,13 +339,13 @@ class PowerBox:
         # Here we multiply by V because the inverse Fourier transform of the
         # dimensionless power has units of 1/V, and we require a unitless
         # quantity for delta_x.
-        dk = self.fftbackend.empty((self.N,) * self.dim, dtype="complex128")
+        dk = self.fftbackend.empty(self._N, dtype="complex128")
         dk[...] = self.delta_k()
         dk[...] = (
             self.V
             * dft.ifft(
                 dk,
-                L=self.boxlength,
+                L=self._boxlength,
                 a=self.fourier_a,
                 b=self.fourier_b,
                 backend=self.fftbackend,
@@ -328,23 +410,25 @@ class PowerBox:
         else:
             dx = delta_x
 
-        dx = (dx + 1) * self.dx**self.dim * nbar
+        dx = (dx + 1) * np.prod(self._axis_dx) * nbar
         n = dx
 
         self.n_per_cell = self.rng.poisson(n)
 
         # Get all source positions
-        args = [self.x] * self.dim
+        args = self._x_axes
         X = np.meshgrid(*args, indexing="ij")
 
         tracer_positions = np.array([x.flatten() for x in X]).T
         tracer_positions = tracer_positions.repeat(self.n_per_cell.flatten(), axis=0)
 
         if randomise_in_cell:
-            tracer_positions += self.rng.uniform(size=(np.sum(self.n_per_cell), self.dim)) * self.dx
+            tracer_positions += self.rng.uniform(
+                size=(np.sum(self.n_per_cell), self.dim)
+            ) * np.asarray(self._axis_dx)
 
         if min_at_zero:
-            tracer_positions += self.boxlength / 2.0
+            tracer_positions += np.asarray(self._boxlength) / 2.0
 
         if store_pos:
             self.tracer_positions = tracer_positions
@@ -356,7 +440,8 @@ class LogNormalPowerBox(PowerBox):
     r"""Calculate Log-Normal density fields with given power spectra.
 
     See the documentation of :class:`PowerBox` for a detailed explanation of the
-    arguments, as this class has exactly the same arguments.
+    arguments, as this class has exactly the same arguments, including scalar or
+    per-axis ``N`` and ``boxlength`` inputs.
 
     This class calculates an (over-)density field of arbitrary dimension given an input
     isotropic power spectrum. In this case, the field has a log-normal distribution of
@@ -399,12 +484,12 @@ class LogNormalPowerBox(PowerBox):
 
     def correlation_array(self):
         """Return the correlation function from the input power on the grid."""
-        pa = self.fftbackend.empty((self.N,) * self.dim)
+        pa = self.fftbackend.empty(self._N)
         pa[...] = self.power_array()
         return self.V * np.real(
             dft.ifft(
                 pa,
-                L=self.boxlength,
+                L=self._boxlength,
                 a=self.fourier_a,
                 b=self.fourier_b,
                 backend=self.fftbackend,
@@ -417,12 +502,12 @@ class LogNormalPowerBox(PowerBox):
 
     def gaussian_power_array(self):
         """Power spectrum required for a Gaussian field to produce the input power."""
-        gca = self.fftbackend.empty((self.N,) * self.dim)
+        gca = self.fftbackend.empty(self._N)
         gca[...] = self.gaussian_correlation_array()
         gpa = np.abs(
             dft.fft(
                 gca,
-                L=self.boxlength,
+                L=self._boxlength,
                 a=self.fourier_a,
                 b=self.fourier_b,
                 backend=self.fftbackend,
@@ -445,13 +530,13 @@ class LogNormalPowerBox(PowerBox):
 
     def delta_x(self):
         """Return the real-space over-density field from the input power spectrum."""
-        dk = self.fftbackend.empty((self.N,) * self.dim, dtype="complex128")
+        dk = self.fftbackend.empty(self._N, dtype="complex128")
         dk[...] = self.delta_k()
         dk[...] = (
             np.sqrt(self.V)
             * dft.ifft(
                 dk,
-                L=self.boxlength,
+                L=self._boxlength,
                 a=self.fourier_a,
                 b=self.fourier_b,
                 backend=self.fftbackend,

--- a/tests/test_discrete.py
+++ b/tests/test_discrete.py
@@ -100,6 +100,23 @@ def test_discrete_power_gaussian_non_cubic() -> None:
     assert np.all(np.isfinite(result.power))
 
 
+def test_create_discrete_sample_warns_and_stores_positions() -> None:
+    pb = PowerBox(
+        N=(24, 32),
+        dim=2,
+        boxlength=(20.0, 35.0),
+        pk=lambda u: 0.1 * (1 + u) ** -1.5,
+        ensure_physical=True,
+    )
+
+    with pytest.warns(UserWarning, match="You Should provide `seed`"):
+        sample = pb.create_discrete_sample(nbar=50.0, store_pos=True, min_at_zero=True)
+
+    assert hasattr(pb, "tracer_positions")
+    np.testing.assert_allclose(sample, pb.tracer_positions)
+    assert np.all(sample >= 0)
+
+
 if __name__ == "__main__":
     test_discrete_power_gaussian()
     test_discrete_power_lognormal()

--- a/tests/test_discrete.py
+++ b/tests/test_discrete.py
@@ -79,6 +79,27 @@ def test_discrete_power_lognormal() -> None:
     get_power(sample, pb.boxlength, N=pb.N, deltax2=sample, dimensionless=False)
 
 
+def test_discrete_power_gaussian_non_cubic() -> None:
+    pb = PowerBox(
+        N=(96, 128),
+        dim=2,
+        boxlength=(80.0, 140.0),
+        pk=lambda u: 0.1 * (1 + u) ** -1.5,
+        ensure_physical=True,
+        seed=1212,
+    )
+
+    box = pb.delta_x()
+    sample = pb.create_discrete_sample(nbar=800.0, delta_x=box, min_at_zero=True)
+    result = get_power(sample, pb.boxlength, N=pb.N)
+
+    assert sample.shape[1] == pb.dim
+    assert np.all(sample >= 0)
+    assert np.all(sample[:, 0] < pb.boxlength[0])
+    assert np.all(sample[:, 1] < pb.boxlength[1])
+    assert np.all(np.isfinite(result.power))
+
+
 if __name__ == "__main__":
     test_discrete_power_gaussian()
     test_discrete_power_lognormal()

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -50,6 +50,44 @@ def test_tuple_inputs_expose_axis_aware_geometry() -> None:
     assert pb.kvec[0].shape == (15,)
     assert pb.kvec[1].shape == (18,)
     assert pb.delta_x().shape == (15, 18)
+    assert pb.r.shape == (15, 18)
+
+
+@pytest.mark.parametrize(
+    ("N", "boxlength", "error", "match"),
+    [
+        ((15,), (3.0, 9.0), ValueError, "N must be a scalar or have length 2"),
+        ((15, 18.5), (3.0, 9.0), TypeError, "N entries must be integers"),
+        ((15, 18), (3.0,), ValueError, "boxlength must be a scalar or have length 2"),
+        ((15, 18), (3.0, "bad"), TypeError, "boxlength entries must be real numbers"),
+    ],
+)
+def test_tuple_input_validation(N, boxlength, error, match) -> None:
+    """Tuple-valued geometry inputs validate length and element types."""
+    with pytest.raises(error, match=match):
+        PowerBox(N, dim=2, pk=lambda k: (1 + k) ** -2.0, boxlength=boxlength)
+
+
+def test_non_volume_normalized_powerbox_uses_input_power_directly() -> None:
+    """Disabling volume normalization leaves the power callable unchanged."""
+    pb = PowerBox(
+        16,
+        dim=2,
+        pk=lambda k: k + 1.0,
+        boxlength=4.0,
+        seed=1234,
+        vol_normalised_power=False,
+    )
+
+    np.testing.assert_allclose(pb.pk(np.array([1.5, 2.5])), np.array([2.5, 3.5]))
+
+
+def test_negative_power_raises() -> None:
+    """Negative input power remains a hard error."""
+    pb = PowerBox(16, dim=2, pk=lambda k: -np.ones_like(k), boxlength=4.0, seed=1234)
+
+    with pytest.raises(ValueError, match="returned negative values"):
+        pb.delta_k()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -19,6 +19,117 @@ from powerbox import (
 get_power = partial(get_power, bins_upto_boxlen=True)
 
 
+def test_scalar_inputs_preserve_scalar_public_attributes() -> None:
+    """Scalar constructor inputs keep the historical public attribute shapes."""
+    pb = PowerBox(16, dim=2, pk=lambda k: (1 + k) ** -2.0, boxlength=4.0, seed=1234)
+
+    assert np.isscalar(pb.N)
+    assert np.isscalar(pb.boxlength)
+    assert isinstance(pb.x, np.ndarray)
+    assert isinstance(pb.kvec, np.ndarray)
+    assert pb.delta_x().shape == (16, 16)
+
+
+def test_tuple_inputs_expose_axis_aware_geometry() -> None:
+    """Tuple inputs produce per-axis public geometry for non-cubic boxes."""
+    pb = PowerBox(
+        (15, 18),
+        dim=2,
+        pk=lambda k: (1 + k) ** -2.0,
+        boxlength=(3.0, 9.0),
+        seed=1234,
+    )
+
+    assert pb.N == (15, 18)
+    assert pb.boxlength == (3.0, 9.0)
+    assert isinstance(pb.x, tuple)
+    assert isinstance(pb.kvec, tuple)
+    assert len(pb.x) == len(pb.kvec) == pb.dim
+    assert pb.x[0].shape == (15,)
+    assert pb.x[1].shape == (18,)
+    assert pb.kvec[0].shape == (15,)
+    assert pb.kvec[1].shape == (18,)
+    assert pb.delta_x().shape == (15, 18)
+
+
+@pytest.mark.parametrize(
+    ("shape", "boxlength"),
+    [
+        ((48, 72), (120.0, 180.0)),
+        ((49, 72), (120.0, 180.0)),
+        ((48, 71), (120.0, 180.0)),
+        ((49, 71), (120.0, 180.0)),
+    ],
+)
+def test_non_cubic_powerbox_power_normalization(shape, boxlength) -> None:
+    """Non-cubic Gaussian fields recover the input power over mixed odd/even shapes."""
+    import powerbox.dft as dft
+
+    def pkfunc(k):
+        return (1 + k) ** -2
+
+    nrealizations = 20
+    power = []
+
+    for seed in range(nrealizations):
+        pb = PowerBox(
+            shape,
+            dim=2,
+            pk=pkfunc,
+            boxlength=boxlength,
+            ensure_physical=False,
+            seed=seed,
+        )
+        power.append(get_power(dft.fftshift(pb.delta_x()), pb.boxlength).power)
+
+    pmean = np.mean(power, axis=0)
+    pstd = np.std(power, axis=0)
+    expected = pkfunc(get_power(dft.fftshift(pb.delta_x()), pb.boxlength).bin_centres)
+    mask = np.isfinite(pstd[1:]) & (pstd[1:] > 0)
+    zscore = np.abs(pmean[1:][mask] - expected[1:][mask]) / (
+        pstd[1:][mask] / np.sqrt(nrealizations)
+    )
+    np.testing.assert_allclose(zscore, 0, atol=6.0)
+
+
+@pytest.mark.parametrize(
+    ("shape", "boxlength"),
+    [
+        ((47, 68), (120.0, 180.0)),
+        ((48, 67), (120.0, 180.0)),
+    ],
+)
+def test_non_cubic_lognormal_power_normalization(shape, boxlength) -> None:
+    """Non-cubic lognormal fields recover the input power."""
+    import powerbox.dft as dft
+
+    def pkfunc(k):
+        return (1 + k) ** -2
+
+    nrealizations = 15
+    power = []
+
+    for seed in range(nrealizations):
+        pb = LogNormalPowerBox(
+            shape,
+            dim=2,
+            pk=pkfunc,
+            boxlength=boxlength,
+            ensure_physical=False,
+            seed=seed,
+        )
+        power.append(get_power(dft.fftshift(pb.delta_x()), pb.boxlength).power)
+
+    pmean = np.mean(power, axis=0)
+    pstd = np.std(power, axis=0)
+    expected = pkfunc(get_power(dft.fftshift(pb.delta_x()), pb.boxlength).bin_centres)
+    mask = np.isfinite(pstd[1:]) & (pstd[1:] > 0)
+    zscore = np.abs(pmean[1:][mask] - expected[1:][mask]) / (
+        pstd[1:][mask] / np.sqrt(nrealizations)
+    )
+    np.testing.assert_allclose(zscore, 0, atol=6.0)
+
+
 def test_power1d() -> None:
     p = [0] * 40
     for i in range(40):

--- a/tests/test_reality_of_deltax.py
+++ b/tests/test_reality_of_deltax.py
@@ -25,6 +25,25 @@ def test_deltax_is_real(ndim, ncells, ab):
     np.testing.assert_allclose(deltax.imag, 0, atol=1e-12)
 
 
+@pytest.mark.parametrize("shape", [(16, 17), (17, 16), (16, 17, 18), (17, 16, 19)])
+@pytest.mark.parametrize("ab", [(0, 1), (0, 2 * np.pi)])
+def test_non_cubic_deltax_is_real(shape, ab):
+    """Mixed odd/even non-cubic delta_x realizations remain real."""
+    boxlength = tuple(float(index + 2) for index in range(len(shape)))
+    pb = PowerBox(pk=lambda k: 1, boxlength=boxlength, N=shape, dim=len(shape), seed=1234)
+
+    dk = pb.delta_k()
+
+    deltax = ifft(
+        dk,
+        L=boxlength,
+        a=ab[0],
+        b=ab[1],
+    )[0]
+
+    np.testing.assert_allclose(deltax.imag, 0, atol=1e-12)
+
+
 @pytest.mark.parametrize("ncells", [4, 5])
 def test_hermitianity_2d(ncells):
     """Test that the gauss_hermitian method produces a Hermitian array in 2D.


### PR DESCRIPTION
## Summary
- allow `PowerBox` and `LogNormalPowerBox` to accept scalar or per-axis `N` and `boxlength`
- preserve existing scalar public behavior while normalizing geometry internally
- add regression tests for non-cubic power recovery and mixed odd/even shapes
- document cuboid usage with a new tutorial page

## Context
- fixes #64
- supersedes #65

## Validation
- uv run ruff format src/powerbox/powerbox.py tests/test_power.py tests/test_reality_of_deltax.py tests/test_discrete.py
- uv run ruff check --fix src/powerbox/powerbox.py tests/test_power.py tests/test_reality_of_deltax.py tests/test_discrete.py
- uv run pytest tests/test_power.py tests/test_reality_of_deltax.py tests/test_discrete.py tests/test_lognormal.py -q

## Summary by Sourcery

Add support for non-cubic (per-axis) grid geometries in Gaussian and lognormal PowerBox fields while preserving existing scalar-based APIs.

New Features:
- Allow PowerBox and LogNormalPowerBox to accept per-axis tuples for N and boxlength to generate cuboid grids.
- Expose axis-aware coordinate and wavenumber geometry via tuple-valued x and kvec attributes when per-axis inputs are used.

Enhancements:
- Normalize grid counts and box lengths internally to per-axis tuples while keeping scalar attributes for backwards compatibility.
- Generalize Hermitian Gaussian field generation and volume/spacing calculations to handle mixed odd/even, non-cubic shapes.

Documentation:
- Add a new cuboid box tutorial demonstrating how to construct and use non-cubic PowerBox geometries.

Tests:
- Add regression tests verifying scalar inputs keep historical public attribute shapes.
- Add tests for non-cubic Gaussian and lognormal fields to confirm power-spectrum recovery across mixed odd/even shapes.
- Add tests ensuring non-cubic delta_x realizations remain real and that discrete sampling works correctly for cuboid boxes.