### PR TITLE
ci: consolidate dependabot upates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,30 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 14
+    groups:
+      incremental:
+        # Group all minor/patch updates together, but not major updates.
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: uv
     directory: "/"
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 14
+    groups:
+      incremental:
+        # Group all minor/patch updates together, but not major updates.
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Consolidates minor/patch updates into one PR, and applies a two-week cooldown period.

## Summary by Sourcery

Configure Dependabot to batch minor and patch updates with a cooldown period for both GitHub Actions and uv dependencies.

Build:
- Add a 14-day cooldown window to Dependabot update schedules for GitHub Actions and uv.
- Group minor and patch version updates into a single incremental Dependabot PR for each ecosystem.